### PR TITLE
Extend debug mode to Replanner class

### DIFF
--- a/replan
+++ b/replan
@@ -52,7 +52,7 @@ class Replan
     Relister.new.execute(content)
   end
 
-  def update(schedule_filename, archive_filename, template_filename:, compare:, move:)
+  def update(schedule_filename, archive_filename, template_filename:, compare:, move:, debug:)
     content = IO.read(schedule_filename)
     original_content = content.dup
 
@@ -60,7 +60,7 @@ class Replan
     content = Readder.new.execute(content)
     content = Retemplater.new(template_filename).execute(content) if template_filename && move
     content = Reworker.new.execute(content) if move
-    content = Replanner.new.execute(content, move)
+    content = Replanner.new.execute(content, move, debug: debug)
 
     conditional_save(content, original_content, schedule_filename, archive_filename, compare: compare, move: move)
   end
@@ -96,7 +96,7 @@ if __FILE__ == $PROGRAM_NAME
       move = !options[:nomove]
       compare = !!options[:compare]
 
-      Replan.new.update(schedule_filename, archive_filename, template_filename: template_filename, compare: compare, move: move)
+      Replan.new.update(schedule_filename, archive_filename, template_filename: template_filename, compare: compare, move: move, debug: debug_mode)
     end
   rescue => error
     if debug_mode

--- a/replan.lib/replan_helper.rb
+++ b/replan.lib/replan_helper.rb
@@ -52,7 +52,7 @@ module ReplanHelper
     header_matches = find_header_matches(content)
     header_dates = header_matches.map(&method(:convert_header_to_date))
 
-    raise "Target date is earlier than then the first available!" if date < header_dates.first
+    raise "Target date (#{date}) is earlier than then the first available (#{header_dates.first})!" if date < header_dates.first
 
     header_dates.each_cons(2) do |previous_date, next_date|
       if previous_date >= next_date

--- a/replan.lib/replanner.rb
+++ b/replan.lib/replanner.rb
@@ -36,7 +36,12 @@ class Replanner
       # so that they will appear in the original order.
       #
       replan_lines.reverse.each do |replan_line|
-        next if date_i > 0 && !@replan_codec.skipped_event?(replan_line)
+        puts "> Processing replan line: #{replan_line.strip}" if debug
+
+        if date_i > 0 && !@replan_codec.skipped_event?(replan_line)
+          puts ">> Skipping" if debug
+          next
+        end
 
         replan_data = decode_replan_data(replan_line)
 

--- a/replan.lib/replanner.rb
+++ b/replan.lib/replanner.rb
@@ -18,7 +18,7 @@ class Replanner
 
   # check_todo: if true and a todo section is found, an error is raised.
   #
-  def execute(content, check_todo)
+  def execute(content, check_todo, debug: false)
     dates = find_all_dates(content)
 
     dates.each_with_index do |current_date, date_i|


### PR DESCRIPTION
When debug mode is set, the Replanner class will also use it; currently, a couple of messages are printed.

Also improved an error message.