### PR TITLE
Replanner: Fix interpolations regex

### DIFF
--- a/replan.lib/replanner.rb
+++ b/replan.lib/replanner.rb
@@ -150,7 +150,7 @@ class Replanner
   def apply_interpolations(line, date)
     INTERPOLATIONS.inject(line) do |line, (token, replacement)|
       new_content = replacement[date]
-      line.gsub(/(.*)\(.*?\)(\{\{#{token}\}\})/s, "\\1(#{new_content})\\2")
+      line.gsub(/(.*)\(.*?\)(\{\{#{token}\}\})/, "\\1(#{new_content})\\2")
     end
   end
 


### PR DESCRIPTION
It seems that the `/s` flag was inadvertly added, and not needed. It's unclear though, why it was present - it doesn't make sense even if it was mistaken for the Perl one.

This would cause an error on multibyte chars (e.g. `"°".gsub(/.*/s, '')`.