### PR TITLE
Move todo checking from the planner to the mover

### DIFF
--- a/replan
+++ b/replan
@@ -60,7 +60,7 @@ class Replan
     content = Readder.new.execute(content)
     content = Retemplater.new(template_filename).execute(content) if template_filename && move
     content = Reworker.new.execute(content) if move
-    content = Replanner.new.execute(content, move, debug: debug)
+    content = Replanner.new.execute(content, debug: debug)
 
     conditional_save(content, original_content, schedule_filename, archive_filename, compare: compare, move: move)
   end

--- a/replan.lib/remover.rb
+++ b/replan.lib/remover.rb
@@ -1,6 +1,8 @@
 require 'fileutils'
 require 'tmpdir'
 
+require_relative 'replan_helper'
+
 class Remover
   include ReplanHelper
 

--- a/replan.lib/remover.rb
+++ b/replan.lib/remover.rb
@@ -2,9 +2,11 @@ require 'fileutils'
 require 'tmpdir'
 
 require_relative 'replan_helper'
+require_relative 'shared_constants'
 
 class Remover
   include ReplanHelper
+  include SharedConstants
 
   def execute(schedule_filename, archive_filename, content)
     current_date_section = remove_section_from_schedule(schedule_filename, content)
@@ -19,6 +21,7 @@ class Remover
     current_date_section = find_date_section(content, current_date)
 
     raise "Found `replan` token into current date (#{current_date}) section!" if current_date_section =~ /\breplan\b/
+    raise "Found todo section into current date (#{current_date}) section!" if current_date_section =~ TODO_SECTION_SEPARATOR_REGEX
 
     content = content.sub(current_date_section, "")
     IO.write(schedule_filename, content)

--- a/replan.lib/replanner.rb
+++ b/replan.lib/replanner.rb
@@ -1,13 +1,11 @@
 require_relative 'replan_codec'
 require_relative 'replan_helper'
-require_relative 'shared_constants'
 
 require 'date'
 require 'English'
 
 class Replanner
   include ReplanHelper
-  include SharedConstants
 
   INTERPOLATIONS = {
     'date' => ->(date) { date.strftime('%a/%d').downcase } # "mon/19"
@@ -17,17 +15,11 @@ class Replanner
     @replan_codec = ReplanCodec.new
   end
 
-  # check_todo: if true and a todo section is found, an error is raised.
-  #
-  def execute(content, check_todo, debug: false)
+  def execute(content, debug: false)
     dates = find_all_dates(content)
 
     dates.each_with_index do |current_date, date_i|
       current_date_section = find_date_section(content, current_date)
-
-      if check_todo && current_date_section =~ TODO_SECTION_SEPARATOR_REGEX
-        raise "Found todo section!"
-      end
 
       edited_current_date_section = current_date_section.dup
 

--- a/spec/replan/replan.lib/relister_spec.rb
+++ b/spec/replan/replan.lib/relister_spec.rb
@@ -3,8 +3,6 @@ require 'date'
 
 require_relative '../../../replan.lib/relister.rb'
 
-# Very basic.
-#
 # WATCH OUT! Relister starts from tomorrow's date, so `Date + 1` must be used.
 #
 describe Relister do

--- a/spec/replan/replan.lib/remover_spec.rb
+++ b/spec/replan/replan.lib/remover_spec.rb
@@ -1,0 +1,21 @@
+require 'rspec'
+require 'tempfile'
+
+require_relative '../../../replan.lib/remover.rb'
+
+describe Remover do
+  it "should raise an error if the current date section includes a todo marker" do
+    content = <<~TXT
+        MON 20/SEP/2021
+    - foo
+    ~~~~~
+    - baz
+
+    TXT
+
+    phony_schedule_file = Tempfile.create('schedule')
+    phony_archive_file = Tempfile.create('archive')
+
+    expect { subject.execute(phony_schedule_file, phony_archive_file, content) }.to raise_error("Found todo section into current date (2021-09-20) section!")
+  end
+end # describe Remover

--- a/spec/replan/replan.lib/replan_codec_spec.rb
+++ b/spec/replan/replan.lib/replan_codec_spec.rb
@@ -3,8 +3,6 @@ require 'rspec'
 require_relative '../../../replan.lib/replan_codec.rb'
 
 describe ReplanCodec do
-  # Basic.
-  #
   context "token extraction" do
     it 'for string with all the functionalities' do
       tokens = subject.extract_replan_tokens('(replan f13:33suU 2w in 3m)')

--- a/spec/replan/replan.lib/replan_helper_spec.rb
+++ b/spec/replan/replan.lib/replan_helper_spec.rb
@@ -3,8 +3,6 @@ require 'rspec'
 
 require_relative '../../../replan.lib/replan_helper.rb'
 
-# Very basic.
-#
 describe ReplanHelper do
   let(:helper) { Class.new { extend ReplanHelper } }
 

--- a/spec/replan/replan.lib/replanner_spec.rb
+++ b/spec/replan/replan.lib/replanner_spec.rb
@@ -20,7 +20,7 @@ module ReplannerSpecHelper
     end
 
     result = Timecop.freeze(BASE_DATE) do
-      subject.execute(test_content, true)
+      subject.execute(test_content)
     end
 
     expect(result).to include(expected_next_date_section)
@@ -34,18 +34,6 @@ describe Replanner do
 
   before :all do
     raise "Remove the Date.parse stubbing!" if Gem.loaded_specs['timecop'].version >= Gem::Version.new('0.10')
-  end
-
-  it "Should raise an error if the todo section separator is found" do
-    test_content = <<~TXT
-          SUN 11/JUL/2021
-      - foo
-      ~~~~~
-      - bar
-
-    TXT
-
-    expect { subject.execute(test_content, true) }.to raise_error("Found todo section!")
   end
 
   it "Should replan a 10+ 'm' date" do

--- a/spec/replan/replan.lib/replanner_spec.rb
+++ b/spec/replan/replan.lib/replanner_spec.rb
@@ -27,8 +27,6 @@ module ReplannerSpecHelper
   end
 end
 
-# Very basic.
-#
 describe Replanner do
   include ReplannerSpecHelper
 

--- a/spec/replan/replan.lib/retemplater_spec.rb
+++ b/spec/replan/replan.lib/retemplater_spec.rb
@@ -3,8 +3,6 @@ require 'stringio'
 
 require_relative '../../../replan.lib/retemplater.rb'
 
-# Very basic.
-#
 describe Retemplater do
   let(:current_day) {
     <<~TXT


### PR DESCRIPTION
The todo section matters only when the enclosing day is being moved. In all the other cases, it doesn't hurt.