### PR TITLE
Workaround Timecop bug with Date.parse

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,8 +12,5 @@ group :development, :test do
 end
 
 group :test do
-  # 0.9.x has a bug that causes Date.parse to return the wrong value: https://github.com/travisjeffery/timecop/issues/222.
-  # 0.8.x is also broken, but with slightly different conditions.
-  #
-  gem 'timecop', '~> 0.8.0'
+  gem 'timecop', '~> 0.9.0'
 end

--- a/replan.lib/replan_helper.rb
+++ b/replan.lib/replan_helper.rb
@@ -127,7 +127,11 @@ module ReplanHelper
     day_number = day_number.to_i
     year = year.to_i
 
-    month_number = Date.parse(month_word).month
+    # Timecop is buggy and poorly maintained. Date.parse has been broken in at least v0.8 and v0.9
+    # (see https://github.com/travisjeffery/timecop/issues/222).
+    # This is the workaround.
+    #
+    month_number = Date.strptime(month_word, '%b').month
 
     Date.new(year, month_number, day_number)
   end

--- a/replan.lib/replanner.rb
+++ b/replan.lib/replanner.rb
@@ -123,7 +123,11 @@ class Replanner
         365 * replan_value[0..-2].to_f
       when /^(\w{3})(\+)?$/
         # This is (currently) valid for `next` only
-        parsed_next = Date.parse($LAST_MATCH_INFO[1])
+        #
+        # In this case, Timecop correctly handles Date.parse (see ReplanHelper#convert_header_to_date),
+        # however, considering the project quality, it's safer to avoid it.
+        #
+        parsed_next = Date.strptime($LAST_MATCH_INFO[1], '%a')
 
         # When parsing weekdays, the date in the current week is always returned, which for Ruby starts
         # on Sunday, so we need to adjust.


### PR DESCRIPTION
Timecop is buggy and poorly maintained. Date.parse has been broken in at least v0.8 and v0.9 (see https://github.com/travisjeffery/timecop/issues/222).

This PR works the problem around; given the workaround, it's been possible to upgrade the gem.