### PR TITLE
Reworker: Add support for higher-level closing entries

### DIFF
--- a/replan.lib/reworker.rb
+++ b/replan.lib/reworker.rb
@@ -154,15 +154,12 @@ class Reworker
 
         work_entry_indentation = current_work_entry.indentation
 
-        # Ignore deeper indented lines.
-        #
-        if indentation.size < work_entry_indentation.size
-          raise "Missing closing entry for work entry #{current_work_entry.inspect}"
-        elsif indentation.size == work_entry_indentation.size
+        if indentation.size <= work_entry_indentation.size
           current_work_entry.end_time = start_time || raise("Subsequent entry has no time! (previous: #{current_work_entry.inspect})")
           work_entries << current_work_entry
           current_work_entry = nil
         end
+        # Ignore deeper (lower) indented lines.
       end
     end
 

--- a/spec/replan/replan.lib/reworker_spec.rb
+++ b/spec/replan/replan.lib/reworker_spec.rb
@@ -18,6 +18,8 @@ describe Reworker do
         . 16:00. foo
       - 16:00. work -10
       - 17:00. foo
+        - 17:20. work
+      - 17:30. foo
       - work 1h
       ~ work 20
 
@@ -37,7 +39,7 @@ describe Reworker do
       - foo
         ````
         brody
-        lpimw -t ye '9:00-10:00, 10:00-15:00 -1.5h, 15:20-16:00, 16:00-17:00 -10, 1h, 20' # -c half|off
+        lpimw -t ye '9:00-10:00, 10:00-15:00 -1.5h, 15:20-16:00, 16:00-17:00 -10, 17:20-17:30, 1h, 20' # -c half|off
         bar
         ````
 
@@ -67,14 +69,10 @@ describe Reworker do
   end
 
   context "errors" do
-    # This also includes the case where a timestamped work entry is the last entry.
-    #
-    it "should raise an error if an equally indented, required, entry is missing" do
+    it "should raise an error if a closing entry is missing" do
       content = <<~TEXT
             MON 07/JUN/2021
-        - 15:00. foo
-          - 15:20. work
-        - 16:00. bar
+        - 15:20. work
 
       TEXT
 


### PR DESCRIPTION
Example:

```
  - 17:20. work
- 17:30. foo
```