### PR TITLE
Minor cleanups/improvements

### DIFF
--- a/replan.lib/reworker.rb
+++ b/replan.lib/reworker.rb
@@ -50,11 +50,23 @@ class Reworker
     end
   end
 
+  # options:
+  #
+  # - :extract_only   only for testing; avoids having to add a subsequent day.
+  #
+  def initialize(extract_only: false)
+    @extract_only = extract_only
+  end
+
+  # If :extract_only was enabled, the addition (to the next day) is not performed.
+  #
   def execute(content)
     current_date = find_first_date(content)
     current_date_section = find_date_section(content, current_date)
 
     work_times = extract_work_times(current_date_section)
+
+    return if @extract_only
 
     next_date = current_date + 1
     next_date_section = find_date_section(content, next_date)

--- a/spec/replan/replan.lib/replanner_spec.rb
+++ b/spec/replan/replan.lib/replanner_spec.rb
@@ -190,41 +190,43 @@ describe Replanner do
       assert_replan(test_content, expected_next_date_section, 2 => Date.new(2021, 9, 22))
     end
 
-    it "Should copy the timestamp, if it's fixed" do
-      test_content = <<~TXT
-          MON 20/SEP/2021
-      - 12:30. foo (replan f 2)
+    context "fixed timestamp" do
+      it "Should copy the timestamp, if it's fixed" do
+        test_content = <<~TXT
+            MON 20/SEP/2021
+        - 12:30. foo (replan f 2)
 
-      TXT
+        TXT
 
-      expected_next_date_section = <<~TXT
-          MON 20/SEP/2021
-      - 12:30. foo
+        expected_next_date_section = <<~TXT
+            MON 20/SEP/2021
+        - 12:30. foo
 
-          WED 22/SEP/2021
-      - 12:30. foo (replan f 2)
-      TXT
+            WED 22/SEP/2021
+        - 12:30. foo (replan f 2)
+        TXT
 
-      assert_replan(test_content, expected_next_date_section, 2 => Date.new(2021, 9, 22))
-    end
+        assert_replan(test_content, expected_next_date_section, 2 => Date.new(2021, 9, 22))
+      end
 
-    it "Should replace the timestamp, if there is a new fixed one" do
-      test_content = <<~TXT
-          MON 20/SEP/2021
-      - 12:30. foo (replan f14:00 2)
+      it "Should replace the timestamp, if there is a new fixed one" do
+        test_content = <<~TXT
+            MON 20/SEP/2021
+        - 12:30. foo (replan f14:00 2)
 
-      TXT
+        TXT
 
-      expected_next_date_section = <<~TXT
-          MON 20/SEP/2021
-      - 12:30. foo
+        expected_next_date_section = <<~TXT
+            MON 20/SEP/2021
+        - 12:30. foo
 
-          WED 22/SEP/2021
-      - 14:00. foo (replan f 2)
-      TXT
+            WED 22/SEP/2021
+        - 14:00. foo (replan f 2)
+        TXT
 
-      assert_replan(test_content, expected_next_date_section, 2 => Date.new(2021, 9, 22))
-    end
+        assert_replan(test_content, expected_next_date_section, 2 => Date.new(2021, 9, 22))
+      end
+    end # context "fixed timestamp"
   end # context "timestamp handling"
 
   context 'next' do

--- a/spec/replan/replan.lib/reworker_spec.rb
+++ b/spec/replan/replan.lib/reworker_spec.rb
@@ -3,6 +3,10 @@ require 'rspec'
 require_relative '../../../replan.lib/reworker.rb'
 
 describe Reworker do
+  # For ease of testing, enable the execute :extract_only option (except where required).
+  #
+  let(:subject) { described_class.new(extract_only: true) }
+
   # Includes all the work formats, although not the whole code paths.
   #
   it 'compute the work times and add the accounting entry to the following day' do
@@ -32,7 +36,7 @@ describe Reworker do
 
     TEXT
 
-    result = subject.execute(content)
+    result = described_class.new.execute(content)
 
     expected_result = <<~TEXT
           TUE 08/JUN/2021

--- a/spec/replan/replan.lib/reworker_spec.rb
+++ b/spec/replan/replan.lib/reworker_spec.rb
@@ -123,5 +123,5 @@ describe Reworker do
         expect { subject.execute(content) }.to raise_error(RuntimeError, "Invalid work line format: #{error_line.inspect}")
       end
     end
-  end # context "invalid work lines should raise an error"
+  end # context "errors"
 end # describe Reworker


### PR DESCRIPTION
- Reworker: Add :extract_only option, for ease of testing
- reworker_spec.rb: Fix wrong comment
- replanner_spec.rb: Cosmetic: Add "fixed timestamp" context