### PR TITLE
Fixed timestamp: Allow no dot/spaces between time and description

### DIFF
--- a/replan.lib/replanner.rb
+++ b/replan.lib/replanner.rb
@@ -181,7 +181,7 @@ class Replanner
       elsif line.start_with?(/. \d{1,2}:\d{2}. /)
         line
       else
-        raise "Fixed timestamp is set, but no timestamp is provided"
+        raise "Fixed timestamp is set, but no timestamp is provided: #{line.rstrip.inspect}"
       end
     else
       # Remove the time.

--- a/replan.lib/replanner.rb
+++ b/replan.lib/replanner.rb
@@ -178,7 +178,7 @@ class Replanner
         # Replace the time with the specified one.
         #
         line.sub(/(?<=^. )\d{1,2}:\d{2}. /, "#{replan_data.fixed_time}. ")
-      elsif line.start_with?(/. \d{1,2}:\d{2}. /)
+      elsif line.start_with?(/. \d{1,2}:\d{2}\b/)
         line
       else
         raise "Fixed timestamp is set, but no timestamp is provided: #{line.rstrip.inspect}"

--- a/spec/replan/replan.lib/replanner_spec.rb
+++ b/spec/replan/replan.lib/replanner_spec.rb
@@ -221,18 +221,20 @@ describe Replanner do
 
     context "fixed timestamp" do
       it "Should copy the timestamp, if it's fixed" do
+        # This is a variation of the standard time description, which is useful for intervals.
+        #
         test_content = <<~TXT
             MON 20/SEP/2021
-        - 12:30. foo (replan f 2)
+        - 12:30-13:00. foo (replan f 2)
 
         TXT
 
         expected_next_date_section = <<~TXT
             MON 20/SEP/2021
-        - 12:30. foo
+        - 12:30-13:00. foo
 
             WED 22/SEP/2021
-        - 12:30. foo (replan f 2)
+        - 12:30-13:00. foo (replan f 2)
         TXT
 
         assert_replan(test_content, expected_next_date_section, 2 => Date.new(2021, 9, 22))

--- a/spec/replan/replan.lib/replanner_spec.rb
+++ b/spec/replan/replan.lib/replanner_spec.rb
@@ -263,7 +263,7 @@ describe Replanner do
 
         TXT
 
-        expect { subject.execute(test_content) }.to raise_error("Fixed timestamp is set, but no timestamp is provided")
+        expect { subject.execute(test_content) }.to raise_error('Fixed timestamp is set, but no timestamp is provided: "- foo (replan f 2)"')
       end
     end # context "fixed timestamp"
   end # context "timestamp handling"


### PR DESCRIPTION
Useful for intervals.