### PR TITLE
Add support for first weekday

### DIFF
--- a/replan.lib/replan_lexer.rb
+++ b/replan.lib/replan_lexer.rb
@@ -74,6 +74,9 @@ class ReplanParser < Racc::Parser
                   when (text = @ss.scan(/-\d+/))
                      action { [:LAST_DAYNUM, text] }
 
+                  when (text = @ss.scan(/\+\d?(mon|tue|wed|thu|fri|sat|sun)/))
+                     action { [:FIRST_DAY, text] }
+
                   when (text = @ss.scan(/f/))
                      action { [:F, text] }
 

--- a/replan.lib/replan_parser.rb
+++ b/replan.lib/replan_parser.rb
@@ -12,7 +12,7 @@ require 'racc/parser.rb'
 
 class ReplanParser < Racc::Parser
 
-module_eval(<<'...end parser.y/module_eval...', 'parser.y', 44)
+module_eval(<<'...end parser.y/module_eval...', 'parser.y', 45)
   attr_accessor :v_f, :v_f_time, :v_s, :v_ul, :v_uu, :v_interval, :v_next_prefix, :v_next
 
   def parse(input)
@@ -43,32 +43,32 @@ module_eval(<<'...end parser.y/module_eval...', 'parser.y', 44)
 ##### State transition tables begin ###
 
 racc_action_table = [
-    20,     9,     2,    10,    11,    12,     9,     3,    10,    11,
-    12,    14,    15,    16,    18,    19,    18,    19,     4,     5,
-    22,    23,    24,    26 ]
+    14,    15,    16,    17,    19,    20,    21,     9,     2,    10,
+    11,    12,     9,     3,    10,    11,    12,    19,    20,     4,
+     5,    23,    24,    25,    27 ]
 
 racc_action_check = [
-     7,     7,     0,     7,     7,     7,     4,     1,     4,     4,
-     4,     6,     6,     6,     6,     6,    23,    23,     2,     3,
-     9,    14,    18,    24 ]
+     6,     6,     6,     6,     6,     6,     7,     7,     0,     7,
+     7,     7,     4,     1,     4,     4,     4,    24,    24,     2,
+     3,     9,    14,    19,    25 ]
 
 racc_action_pointer = [
-     0,     7,    15,    19,     2,   nil,     2,    -3,   nil,    15,
-   nil,   nil,   nil,   nil,    18,   nil,   nil,   nil,    19,   nil,
-   nil,   nil,   nil,     4,    14,   nil,   nil ]
+     6,    13,    16,    20,     8,   nil,    -9,     3,   nil,    16,
+   nil,   nil,   nil,   nil,    19,   nil,   nil,   nil,   nil,    20,
+   nil,   nil,   nil,   nil,     4,    15,   nil,   nil ]
 
 racc_action_default = [
-   -18,   -18,   -18,   -18,    -2,    27,   -18,   -18,    -5,    -6,
-    -8,    -9,   -10,    -1,   -11,   -13,   -14,   -15,   -18,   -17,
-    -3,    -4,    -7,   -18,   -18,   -12,   -16 ]
+   -19,   -19,   -19,   -19,    -2,    28,   -19,   -19,    -5,    -6,
+    -8,    -9,   -10,    -1,   -11,   -13,   -14,   -15,   -16,   -19,
+   -18,    -3,    -4,    -7,   -19,   -19,   -12,   -17 ]
 
 racc_goto_table = [
-    17,     8,     1,     6,    21,    13,     7,   nil,   nil,   nil,
-   nil,   nil,   nil,   nil,   nil,   nil,   nil,    25 ]
+    18,     8,     1,     6,    22,    13,     7,   nil,   nil,   nil,
+   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,    26 ]
 
 racc_goto_check = [
      6,     5,     1,     2,     5,     3,     4,   nil,   nil,   nil,
-   nil,   nil,   nil,   nil,   nil,   nil,   nil,     6 ]
+   nil,   nil,   nil,   nil,   nil,   nil,   nil,   nil,     6 ]
 
 racc_goto_pointer = [
    nil,     2,    -1,    -1,     2,    -3,    -6 ]
@@ -78,27 +78,28 @@ racc_goto_default = [
 
 racc_reduce_table = [
   0, 0, :racc_error,
-  4, 15, :_reduce_none,
-  0, 16, :_reduce_none,
-  2, 16, :_reduce_none,
-  2, 18, :_reduce_none,
+  4, 16, :_reduce_none,
+  0, 17, :_reduce_none,
+  2, 17, :_reduce_none,
+  2, 19, :_reduce_none,
+  1, 19, :_reduce_none,
+  1, 20, :_reduce_6,
+  2, 20, :_reduce_7,
+  1, 20, :_reduce_8,
+  1, 20, :_reduce_9,
+  1, 20, :_reduce_10,
+  1, 18, :_reduce_11,
+  3, 18, :_reduce_12,
+  1, 18, :_reduce_13,
+  1, 18, :_reduce_14,
+  1, 18, :_reduce_15,
   1, 18, :_reduce_none,
-  1, 19, :_reduce_6,
-  2, 19, :_reduce_7,
-  1, 19, :_reduce_8,
-  1, 19, :_reduce_9,
-  1, 19, :_reduce_10,
-  1, 17, :_reduce_11,
-  3, 17, :_reduce_12,
-  1, 17, :_reduce_13,
-  1, 17, :_reduce_14,
-  1, 17, :_reduce_none,
-  3, 20, :_reduce_16,
-  1, 20, :_reduce_17 ]
+  3, 21, :_reduce_17,
+  1, 21, :_reduce_18 ]
 
-racc_reduce_n = 18
+racc_reduce_n = 19
 
-racc_shift_n = 27
+racc_shift_n = 28
 
 racc_token_table = {
   false => 0,
@@ -113,10 +114,11 @@ racc_token_table = {
   :INTERVAL => 9,
   :LAST_DAY => 10,
   :LAST_DAYNUM => 11,
-  :IN => 12,
-  :DAY => 13 }
+  :FIRST_DAY => 12,
+  :IN => 13,
+  :DAY => 14 }
 
-racc_nt_base = 14
+racc_nt_base = 15
 
 racc_use_result_var = true
 
@@ -149,6 +151,7 @@ Racc_token_to_s_table = [
   "INTERVAL",
   "LAST_DAY",
   "LAST_DAYNUM",
+  "FIRST_DAY",
   "IN",
   "DAY",
   "$start",
@@ -238,17 +241,24 @@ module_eval(<<'.,.,', 'parser.y', 27)
   end
 .,.,
 
-# reduce 15 omitted
+module_eval(<<'.,.,', 'parser.y', 28)
+  def _reduce_15(val, _values, result)
+     self.v_interval = val.fetch(0)
+    result
+  end
+.,.,
 
-module_eval(<<'.,.,', 'parser.y', 32)
-  def _reduce_16(val, _values, result)
+# reduce 16 omitted
+
+module_eval(<<'.,.,', 'parser.y', 33)
+  def _reduce_17(val, _values, result)
      self.v_next_prefix = val.fetch(0); self.v_next = val.fetch(2)
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 33)
-  def _reduce_17(val, _values, result)
+module_eval(<<'.,.,', 'parser.y', 34)
+  def _reduce_18(val, _values, result)
      self.v_next = val.fetch(0)
     result
   end

--- a/replan.lib/replanner.rb
+++ b/replan.lib/replanner.rb
@@ -132,6 +132,21 @@ class Replanner
         30 * replan_value[0..-2].to_f
       when /^\d+(\.\d)?y$/
         365 * replan_value[0..-2].to_f
+      when /^\+(\d)?(\w{3})$/
+        # This is (currently) valid for `interval` only
+        # Assumes that the input is valid.
+
+        weekday_number = $LAST_MATCH_INFO[1]&.to_i || 1
+
+        # Algorithm similar to negative weekday
+
+        candidate = Date.strptime($LAST_MATCH_INFO[2], '%a')
+        candidate += 7 if candidate == Date.today
+
+        while true
+          break candidate - current_date if (candidate.day / 7) + 1 == weekday_number
+          candidate += 7
+        end
       when /^-(\d+)$/
         # This is (currently) valid for `interval` only
 

--- a/replan_parser/build.sh
+++ b/replan_parser/build.sh
@@ -21,6 +21,8 @@ ruby -r "$(dirname "$0")"/../replan.lib/replan_parser.rb <<'RUBY'
     "replan mon+",
     "replan -mon",
     "replan -11",
+    "replan +mon",
+    "replan +2mon",
     "replan 2w in 3d",
     "replan fsu 2w in 3d",
   ]

--- a/replan_parser/lexer.rex
+++ b/replan_parser/lexer.rex
@@ -7,6 +7,7 @@ macro
   DAY         (mon|tue|wed|thu|fri|sat|sun)\+?
   LAST_DAY    -(mon|tue|wed|thu|fri|sat|sun)
   LAST_DAYNUM -\d+
+  FIRST_DAY   \+\d?(mon|tue|wed|thu|fri|sat|sun)
   F           f
   S           s
   U_LOW       u
@@ -21,6 +22,7 @@ rule
   {DAY}         { [:DAY, text] }
   {LAST_DAY}    { [:LAST_DAY, text] }
   {LAST_DAYNUM} { [:LAST_DAYNUM, text] }
+  {FIRST_DAY}   { [:FIRST_DAY, text] }
   {F}           { [:F, text] }
   {S}           { [:S, text] }
   {U_LOW}       { [:U_LOW, text] }

--- a/replan_parser/parser.y
+++ b/replan_parser/parser.y
@@ -26,6 +26,7 @@ rule
     | INTERVAL WHITESPACE next     { self.v_interval = val.fetch(0) }
     | LAST_DAY                     { self.v_interval = val.fetch(0) }
     | LAST_DAYNUM                  { self.v_interval = val.fetch(0) }
+    | FIRST_DAY                    { self.v_interval = val.fetch(0) }
     | next
     ;
 

--- a/spec/replan/replan.lib/replanner_spec.rb
+++ b/spec/replan/replan.lib/replanner_spec.rb
@@ -79,7 +79,7 @@ describe Replanner do
       assert_replan(test_content, expected_next_date_section)
     end
 
-    it "Should replan on the same month when not available" do
+    it "Should replan on the next month when not available" do
       test_content = <<~TXT
           THU 30/SEP/2021
       - foo (replan -1)

--- a/spec/replan/replan.lib/replanner_spec.rb
+++ b/spec/replan/replan.lib/replanner_spec.rb
@@ -58,6 +58,68 @@ describe Replanner do
     assert_replan(test_content, expected_next_date_section)
   end
 
+  context "first weekday of month interval" do
+    context "without number specifier" do
+      # This behavior may be changed.
+      #
+      it "Should replan on the same month when available" do
+        test_content = <<~TXT
+            WED 01/SEP/2021
+        - foo (replan +thu)
+
+        TXT
+
+        expected_next_date_section = <<~TXT
+            WED 01/SEP/2021
+        - foo
+
+            THU 02/SEP/2021
+        - foo (replan +thu)
+        TXT
+
+        assert_replan(test_content, expected_next_date_section, current_date: Date.new(2021, 9, 1))
+      end
+
+      it "Should replan on the same month when not available" do
+        test_content = <<~TXT
+            MON 27/SEP/2021
+        - foo (replan +mon)
+
+        TXT
+
+        expected_next_date_section = <<~TXT
+            MON 27/SEP/2021
+        - foo
+
+            MON 04/OCT/2021
+        - foo (replan +mon)
+        TXT
+
+        assert_replan(test_content, expected_next_date_section, current_date: Date.new(2021, 9, 27))
+      end
+    end # context "without number specifier" do
+
+    context "with number specifier" do
+      it "Should replan on the same month when available" do
+        test_content = <<~TXT
+            WED 01/SEP/2021
+        - foo (replan +2wed)
+
+        TXT
+
+        expected_next_date_section = <<~TXT
+            WED 01/SEP/2021
+        - foo
+
+            WED 08/SEP/2021
+        - foo (replan +2wed)
+        TXT
+
+        assert_replan(test_content, expected_next_date_section, current_date: Date.new(2021, 9, 1))
+      end
+    end # context "with number specifier" do
+  end # context "last numbered day of month interval"
+
   context "last numbered day of month interval" do
     # This behavior may be changed.
     #


### PR DESCRIPTION
Allow specifying, as target date, the first (optionally numbered) weekday of the month; examples

- `replan +thu`: first thursday of the month
- `replan +2thu`: second thursday of the month

Same considerations of #67 apply, WRT placement in the current month.