### PR TITLE
Make console error message clearer (prefix with `ERROR: `)

### DIFF
--- a/replan
+++ b/replan
@@ -120,7 +120,7 @@ if __FILE__ == $PROGRAM_NAME
     if debug_mode
       raise error
     else
-      puts error
+      puts "ERROR: error"
       exit 1
     end
   end


### PR DESCRIPTION
In some cases (e.g. debug raise without message), it otherwise gets confusing, because nothing is printed.