### PR TITLE
Replace xdotool prefill hack with Readline pre_input_hook

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
 gem 'abbrev'
-gem 'highline',         '~> 3.1.1'
+gem 'reline'
 gem 'simple_scripting', '~> 0.14.1'
 
 group :development do

--- a/replan.lib/input_helper.rb
+++ b/replan.lib/input_helper.rb
@@ -1,26 +1,18 @@
-require 'highline'
+require 'reline'
 
 class InputHelper
-  # input_description: A description of what is asked, e.g. "socks size"
-  #
   def ask(message, prefill: "")
     puts message
 
     if prefill != ""
-      # MWAAAAAHAHAHAH!!
-      #
-      # This hack is not intended to be used on space shuttles or codebases requiring determinism. 🧐😂
-      #
-      Thread.new do
-        sleep 0.2
-
-        `xdotool key Tab`
-      end
+      Reline.pre_input_hook = -> {
+        Reline.insert_text(prefill)
+        Reline.redisplay
+      }
     end
 
-    # It seems there isn't a simple a simple solution to this.
-    # This approach is a hack of the solution at https://stackoverflow.com/a/41522086/210029.
-    #
-    HighLine.new.ask("") { |q| q.completion = [prefill]; q.readline = true }
+    Reline.readline("", true)
+  ensure
+    Reline.pre_input_hook = nil
   end
 end

--- a/spec/replan/replan.lib/input_helper_spec.rb
+++ b/spec/replan/replan.lib/input_helper_spec.rb
@@ -1,0 +1,94 @@
+require 'rspec'
+require 'reline'
+require 'pty'
+require 'tempfile'
+require 'timeout'
+require 'shellwords'
+
+require_relative '../../../replan.lib/input_helper.rb'
+
+describe InputHelper do
+  describe '#ask' do
+    before do
+      Reline.pre_input_hook = nil
+      allow($stdout).to receive(:puts)
+    end
+
+    after do
+      Reline.pre_input_hook = nil
+    end
+
+    it 'returns the value entered by the user' do
+      allow(Reline).to receive(:readline).and_return('user input')
+
+      result = described_class.new.ask('Enter something:')
+
+      expect(result).to eq('user input')
+    end
+
+    it 'pre-fills the editable buffer via Reline.insert_text when a prefill is provided' do
+      expect(Reline).to receive(:insert_text).with('my prefill')
+      allow(Reline).to receive(:redisplay)
+
+      allow(Reline).to receive(:readline) do
+        Reline.pre_input_hook.call
+        'returned'
+      end
+
+      described_class.new.ask('Enter something:', prefill: 'my prefill')
+    end
+
+    it 'does not register a pre_input_hook when prefill is empty' do
+      hook_during_readline = :unset
+      allow(Reline).to receive(:readline) do
+        hook_during_readline = Reline.pre_input_hook
+        'returned'
+      end
+
+      described_class.new.ask('Enter something:')
+
+      expect(hook_during_readline).to be_nil
+    end
+
+    it 'clears the pre_input_hook after the call returns' do
+      allow(Reline).to receive(:readline).and_return('returned')
+      allow(Reline).to receive(:insert_text)
+      allow(Reline).to receive(:redisplay)
+
+      described_class.new.ask('Enter something:', prefill: 'pre')
+
+      expect(Reline.pre_input_hook).to be_nil
+    end
+
+    # Integration test against a real TTY via PTY, to prove that Reline actually presents the
+    # prefill as an editable buffer (not just that we wired the hooks correctly).
+    #
+    it 'produces an editable prefilled buffer under a real Reline (pty integration)' do
+      input_helper_path = File.expand_path('../../../replan.lib/input_helper.rb', __dir__)
+      result_file = Tempfile.new('input_helper_result')
+      result_file.close
+
+      child_script = <<~RUBY
+        require #{input_helper_path.inspect}
+        result = InputHelper.new.ask('prompt:', prefill: 'hello world')
+        File.write(#{result_file.path.inspect}, result)
+      RUBY
+
+      Timeout.timeout(5) do
+        PTY.spawn('ruby', '-e', child_script) do |reader, writer, pid|
+          # Wait for Reline to echo the inserted prefill before sending Enter.
+          #
+          buffer = ''
+          buffer << reader.readpartial(1024) until buffer.include?('hello world')
+
+          writer.write("\n")
+          Process.wait(pid)
+        end
+      end
+
+      expect(File.read(result_file.path)).to eq('hello world')
+    ensure
+      result_file&.unlink
+    end
+  end
+end


### PR DESCRIPTION
Use Readline.pre_input_hook + Readline.insert_text to present an
editable prefilled buffer, instead of spawning a background thread that
fires `xdotool key Tab` 200ms later. The previous approach was racy,
X11-only, and silently failed under Wayland or when the terminal lost
focus — leaving the user with an empty prompt and no indication of
which entry was being updated.

Drop highline (no remaining users) and add reline to silence the Ruby
3.4 deprecation warning emitted by `require 'readline'`.

Add unit specs covering the hook wiring, plus a PTY-based integration
test that spawns a real subprocess and confirms Readline actually
presents the prefill as an editable buffer.