### PR TITLE
CI: refresh Ruby matrix to supported versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: [head, 3.3, 3.2, 3.1]
+        ruby-version: [head, 4.0, 3.4, 3.3]
     continue-on-error: ${{ endsWith(matrix.ruby-version, 'head') || matrix.ruby-version == 'debug' }}
     steps:
     - uses: actions/checkout@v5


### PR DESCRIPTION
Drop EOL 3.1 and 3.2; add current stable 4.0 and 3.4.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>